### PR TITLE
Fix auth component registration issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # FlinkDink Native App
 
 A clean starter for a toddler flashcard app using Expo and React Native.
+
+## Troubleshooting
+
+### "Component auth has not been registered yet"
+
+If you encounter a runtime error stating that the `auth` component has not been
+registered when launching the native build, ensure that the `index.js` file
+registers both the `main` and `auth` entry points. The repository now includes a
+compatibility helper to avoid this issue.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
+import { AppRegistry } from 'react-native';
 import { registerRootComponent } from 'expo';
 import App from './App';
 
+// Register both 'main' and 'auth' component names to avoid runtime
+// "Component ... has not been registered yet" errors on native builds.
+// Some older configuration may look for the "auth" root, while Expo
+// expects "main". Registering both ensures compatibility.
+AppRegistry.registerComponent('auth', () => App);
 registerRootComponent(App);


### PR DESCRIPTION
## Summary
- register 'auth' component entry for legacy builds
- document how to resolve "Component auth has not been registered" error

## Testing
- `npm test --silent` *(fails: no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_685dd4e4e7a0832eafa71ac35f0b3cef