### PR TITLE
Fix auth registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ A clean starter for a toddler flashcard app using Expo and React Native.
 If you encounter a runtime error stating that the `auth` component has not been
 registered when launching the native build, ensure that the `index.js` file
 registers both the `main` and `auth` entry points. The repository now includes a
-compatibility helper to avoid this issue.
+compatibility helper to avoid this issue. After updating `index.js`, run
+`expo start -c` or rebuild the native project to clear any stale caches that may
+cause the old entry point configuration to persist.

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@ import { AppRegistry } from 'react-native';
 import { registerRootComponent } from 'expo';
 import App from './App';
 
-// Register both 'main' and 'auth' component names to avoid runtime
-// "Component ... has not been registered yet" errors on native builds.
-// Some older configuration may look for the "auth" root, while Expo
-// expects "main". Registering both ensures compatibility.
+// Explicitly register both "main" and "auth" entry points. This covers
+// cases where native projects still reference the deprecated "auth"
+// component name. We also register "main" directly to guard against
+// environments that bypass Expo's helper.
+AppRegistry.registerComponent('main', () => App);
 AppRegistry.registerComponent('auth', () => App);
+
 registerRootComponent(App);


### PR DESCRIPTION
## Summary
- register both main and auth entry points explicitly
- clarify cache clearing steps in troubleshooting docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dd63736fc832ea48c9fea58795d7c