### PR TITLE
Normalize curriculum image keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ registers both the `main` and `auth` entry points. The repository now includes a
 compatibility helper to avoid this issue. After updating `index.js`, run
 `expo start -c` or rebuild the native project to clear any stale caches that may
 cause the old entry point configuration to persist.
+
+## Curriculum Images
+
+Curriculum week data references images using just the file name. When adding or
+editing week data, omit the `/images/` prefix. The `imageMap` utility maps these
+filenames to actual assets.

--- a/app/src/data/curriculum/term1/weeks/week001.ts
+++ b/app/src/data/curriculum/term1/weeks/week001.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Dalmation",
       "query": "Dalmatian",
       "fact": "A spotted working dog.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "worshond",
       "title": "Worshond",
       "query": "Dachshund",
       "fact": "Also called a sausage dog because of its shape.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "golden-retriever",
       "title": "Golden Retriever",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "windhond",
       "title": "Windhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rifrug",
       "title": "Rifrug",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "ierse-wolfhond",
       "title": "Ierse Wolfhond",
       "query": "Irish Wolfhound",
       "fact": "One of the tallest dog breeds.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "vizsla",
       "title": "Vizsla",
       "query": "Vizsla",
       "fact": "Vizslas are energetic hunting dogs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "skaaphond",
       "title": "Skaaphond",
       "query": "Sheepdog",
       "fact": "Sheepdogs help herd livestock.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "mathWindowLength": 5,

--- a/app/src/data/curriculum/term1/weeks/week002.ts
+++ b/app/src/data/curriculum/term1/weeks/week002.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Kitaar",
       "query": "Guitar",
       "fact": "A popular string instrument used in many music styles.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "klavier",
       "title": "Klavier",
       "query": "Piano",
       "fact": "Produces sound when keys strike internal strings.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "dromme",
       "title": "Dromme",
       "query": "Drums",
       "fact": "Percussion instrument played by striking skins or pads.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "mandolien",
       "title": "Mandolien",
       "query": "Mandolin",
       "fact": "A small string instrument typically plucked with a pick.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "trompet",
       "title": "Trompet",
       "query": "Trumpet",
       "fact": "Brass instrument known for its bright, powerful sound.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "viool",
       "title": "Viool",
       "query": "Violin",
       "fact": "The smallest high-pitched instrument in the string family.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "fluit",
       "title": "Fluit",
       "query": "Flute",
       "fact": "Woodwind instrument played by blowing across an opening.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "saksofoon",
       "title": "Saksofoon",
       "query": "Saxophone",
       "fact": "Woodwind instrument commonly used in jazz music.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "harp",
       "title": "Harp",
       "query": "Harp",
       "fact": "Large instrument with many strings plucked by hand.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "doedelsak",
       "title": "Doedelsak",
       "query": "Bagpipes",
       "fact": "Traditional instrument that uses air stored in a bag.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     }
   ],
   "mathWindowLength": 10,

--- a/app/src/data/curriculum/term1/weeks/week003.ts
+++ b/app/src/data/curriculum/term1/weeks/week003.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Swartkorhaan",
       "query": "Black korhaan",
       "fact": "A ground-dwelling bird known for its striking black and white plumage.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "swartkopreier",
       "title": "Swartkopreier",
       "query": "Black-headed heron",
       "fact": "Tall wading bird often seen stalking in wetlands.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "blouvalk",
       "title": "Blouvalk",
       "query": "Pale chanting goshawk",
       "fact": "This raptor hunts from perches in open areas.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "bloukraanvoel",
       "title": "Bloukraanvoël",
       "query": "Blue crane",
       "fact": "South Africa's graceful national bird.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "bruinvalk",
       "title": "Bruinvalk",
       "query": "Brown hawk",
       "fact": "Medium-sized bird of prey with brown plumage.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "tortelduif",
       "title": "Tortelduif",
       "query": "Turtle dove",
       "fact": "Small dove famous for its gentle call.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "bosluisvoel",
       "title": "Bosluisvoël",
       "query": "Oxpecker",
       "fact": "Feeds on ticks found on large mammals.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "kiewiet",
       "title": "Kiewiet",
       "query": "Lapwing",
       "fact": "Ground-nesting bird known for its loud alarm calls.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "europese-byvreter",
       "title": "Europese byvreter",
       "query": "European bee-eater",
       "fact": "Colorful bird that catches insects in flight.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "europese-swawel",
       "title": "Europese swawel",
       "query": "European swallow",
       "fact": "Migratory swallow that nests under roofs.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     }
   ],
   "mathWindowLength": 10,

--- a/app/src/data/curriculum/term1/weeks/week004.ts
+++ b/app/src/data/curriculum/term1/weeks/week004.ts
@@ -18,70 +18,70 @@ export default {
       "title": "graafmasjien",
       "query": "Excavator",
       "fact": "A powerful machine used for digging.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "trekker",
       "title": "trekker",
       "query": "Tractor",
       "fact": "Tractors help pull heavy loads.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "hyskraan",
       "title": "hyskraan",
       "query": "Crane",
       "fact": "Used to lift heavy objects on site.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "vullistrok",
       "title": "vullistrok",
       "query": "Garbage truck",
       "fact": "Truck that collects waste.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "padroller",
       "title": "padroller",
       "query": "Road roller",
       "fact": "Heavy vehicle that compacts road surfaces.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "grader",
       "title": "grader",
       "query": "Grader",
       "fact": "Machine that levels soil or roads.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "forklift",
       "title": "forklift",
       "query": "Forklift",
       "fact": "Used in warehouses to move pallets.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "bulldozer",
       "title": "bulldozer",
       "query": "Bulldozer",
       "fact": "Large machine with a blade for pushing earth.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "sementmenger",
       "title": "sementmenger",
       "query": "Cement mixer",
       "fact": "Mixes cement for building.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "stroper",
       "title": "stroper",
       "query": "Harvester",
       "fact": "Machine that harvests crops.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     }
   ],
   "mathWindowLength": 10,

--- a/app/src/data/curriculum/term1/weeks/week005.ts
+++ b/app/src/data/curriculum/term1/weeks/week005.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Vlieg",
       "query": "fly",
       "fact": "A small insect often found near food.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "stokgogga",
       "title": "Stokgogga",
       "query": "stick insect",
       "fact": "Mimics twigs to hide from predators.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "mot",
       "title": "Mot",
       "query": "moth",
       "fact": "Night-flying insect drawn to lights.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "mier",
       "title": "Mier",
       "query": "ant",
       "fact": "Hard-working insect living in colonies.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "kakkerlak",
       "title": "Kakkerlak",
       "query": "cockroach",
       "fact": "Tough insect that can live almost anywhere.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "lieweheersbesie",
       "title": "Lieweheersbesie",
       "query": "ladybug",
       "fact": "Spotted beetle that eats garden pests.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "by",
       "title": "By",
       "query": "bee",
       "fact": "Pollinator famous for making honey.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "naaldekoker",
       "title": "Naaldekoker",
       "query": "dragonfly",
       "fact": "Swift flyer that hunts near water.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "vuurvliegie",
       "title": "Vuurvliegie",
       "query": "firefly",
       "fact": "Glows at night using natural light.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "hottentotsgot",
       "title": "Hottentotsgot",
       "query": "praying mantis",
       "fact": "Predator that folds its long front legs.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     }
   ]
 }

--- a/app/src/data/curriculum/term1/weeks/week006.ts
+++ b/app/src/data/curriculum/term1/weeks/week006.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Dahlia",
       "query": "dahlia",
       "fact": "This flower is prized for its bright, full blooms.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "protea",
       "title": "Protea",
       "query": "protea",
       "fact": "Known for its striking, spiky petals.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "malva",
       "title": "Malva",
       "query": "mallow",
       "fact": "Also called mallow, it has delicate, colorful flowers.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "hesperantha-aandblom",
       "title": "Hesperantha (aandblom)",
       "query": "hesperantha",
       "fact": "The evening flower opens its petals at sunset.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "kappertjie",
       "title": "Kappertjie",
       "query": "nasturtium",
       "fact": "Nasturtiums add a peppery flavor to salads.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "ranonkel",
       "title": "Ranonkel",
       "query": "ranunculus",
       "fact": "Ranunculus blooms in many vibrant colors.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "sonneblom",
       "title": "Sonneblom",
       "query": "sunflower",
       "fact": "The sunflower turns its head to follow the sun.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "lelie",
       "title": "Lelie",
       "query": "lily",
       "fact": "Lilies are famous for their fragrant blossoms.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "roos",
       "title": "Roos",
       "query": "rose",
       "fact": "Roses symbolize love and affection.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     },
     {
       "id": "tulp",
       "title": "Tulp",
       "query": "tulip",
       "fact": "Tulips are early spring flowers with cup-shaped blooms.",
-      "image": "/images/placeholder.png"
+      "image": "placeholder.png"
     }
   ]
 }

--- a/app/src/data/curriculum/term1/weeks/week007.ts
+++ b/app/src/data/curriculum/term1/weeks/week007.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ]
 }

--- a/app/src/data/curriculum/term1/weeks/week008.ts
+++ b/app/src/data/curriculum/term1/weeks/week008.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ]
 }

--- a/app/src/data/curriculum/term1/weeks/week009.ts
+++ b/app/src/data/curriculum/term1/weeks/week009.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ]
 }

--- a/app/src/data/curriculum/term1/weeks/week010.ts
+++ b/app/src/data/curriculum/term1/weeks/week010.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Dalmation",
       "query": "Dalmatian",
       "fact": "A spotted working dog.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "worshond",
       "title": "Worshond",
       "query": "Dachshund",
       "fact": "Also called a sausage dog because of its shape.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "golden-retriever",
       "title": "Golden Retriever",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "windhond",
       "title": "Windhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rifrug",
       "title": "Rifrug",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "ierse-wolfhond",
       "title": "Ierse Wolfhond",
       "query": "Irish Wolfhound",
       "fact": "One of the tallest dog breeds.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "vizsla",
       "title": "Vizsla",
       "query": "Vizsla",
       "fact": "Vizslas are energetic hunting dogs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "skaaphond",
       "title": "Skaaphond",
       "query": "Sheepdog",
       "fact": "Sheepdogs help herd livestock.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ]
 }

--- a/app/src/data/curriculum/term2/weeks/week011.ts
+++ b/app/src/data/curriculum/term2/weeks/week011.ts
@@ -14,70 +14,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "addition": [

--- a/app/src/data/curriculum/term2/weeks/week012.ts
+++ b/app/src/data/curriculum/term2/weeks/week012.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "addition": [

--- a/app/src/data/curriculum/term2/weeks/week013.ts
+++ b/app/src/data/curriculum/term2/weeks/week013.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
 "addition": [

--- a/app/src/data/curriculum/term2/weeks/week014.ts
+++ b/app/src/data/curriculum/term2/weeks/week014.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
 "addition": [

--- a/app/src/data/curriculum/term2/weeks/week015.ts
+++ b/app/src/data/curriculum/term2/weeks/week015.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
 "addition": [

--- a/app/src/data/curriculum/term2/weeks/week016.ts
+++ b/app/src/data/curriculum/term2/weeks/week016.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
 "addition": [

--- a/app/src/data/curriculum/term2/weeks/week017.ts
+++ b/app/src/data/curriculum/term2/weeks/week017.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "subtraction": [

--- a/app/src/data/curriculum/term2/weeks/week018.ts
+++ b/app/src/data/curriculum/term2/weeks/week018.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "subtraction": [

--- a/app/src/data/curriculum/term2/weeks/week019.ts
+++ b/app/src/data/curriculum/term2/weeks/week019.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Dalmation",
       "query": "Dalmatian",
       "fact": "A spotted working dog.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "worshond",
       "title": "Worshond",
       "query": "Dachshund",
       "fact": "Also called a sausage dog because of its shape.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "golden-retriever",
       "title": "Golden Retriever",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "windhond",
       "title": "Windhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rifrug",
       "title": "Rifrug",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "ierse-wolfhond",
       "title": "Ierse Wolfhond",
       "query": "Irish Wolfhound",
       "fact": "One of the tallest dog breeds.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "vizsla",
       "title": "Vizsla",
       "query": "Vizsla",
       "fact": "Vizslas are energetic hunting dogs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "skaaphond",
       "title": "Skaaphond",
       "query": "Sheepdog",
       "fact": "Sheepdogs help herd livestock.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "subtraction": [

--- a/app/src/data/curriculum/term2/weeks/week020.ts
+++ b/app/src/data/curriculum/term2/weeks/week020.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "subtraction": [

--- a/app/src/data/curriculum/term3/weeks/week021.ts
+++ b/app/src/data/curriculum/term3/weeks/week021.ts
@@ -21,70 +21,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "addition": [

--- a/app/src/data/curriculum/term3/weeks/week022.ts
+++ b/app/src/data/curriculum/term3/weeks/week022.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "addition": [

--- a/app/src/data/curriculum/term3/weeks/week023.ts
+++ b/app/src/data/curriculum/term3/weeks/week023.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "multiplication": [

--- a/app/src/data/curriculum/term3/weeks/week024.ts
+++ b/app/src/data/curriculum/term3/weeks/week024.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-    "image": "/images/dog.svg"
+    "image": "dog.svg"
     }
   ],
   "multiplication": [

--- a/app/src/data/curriculum/term3/weeks/week025.ts
+++ b/app/src/data/curriculum/term3/weeks/week025.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "division": [

--- a/app/src/data/curriculum/term3/weeks/week026.ts
+++ b/app/src/data/curriculum/term3/weeks/week026.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "division": [

--- a/app/src/data/curriculum/term3/weeks/week027.ts
+++ b/app/src/data/curriculum/term3/weeks/week027.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "division": [

--- a/app/src/data/curriculum/term3/weeks/week028.ts
+++ b/app/src/data/curriculum/term3/weeks/week028.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Dalmation",
       "query": "Dalmatian",
       "fact": "A spotted working dog.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "worshond",
       "title": "Worshond",
       "query": "Dachshund",
       "fact": "Also called a sausage dog because of its shape.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "golden-retriever",
       "title": "Golden Retriever",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "windhond",
       "title": "Windhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rifrug",
       "title": "Rifrug",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "ierse-wolfhond",
       "title": "Ierse Wolfhond",
       "query": "Irish Wolfhound",
       "fact": "One of the tallest dog breeds.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "vizsla",
       "title": "Vizsla",
       "query": "Vizsla",
       "fact": "Vizslas are energetic hunting dogs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "skaaphond",
       "title": "Skaaphond",
       "query": "Sheepdog",
       "fact": "Sheepdogs help herd livestock.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "division": [

--- a/app/src/data/curriculum/term3/weeks/week029.ts
+++ b/app/src/data/curriculum/term3/weeks/week029.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "division": [

--- a/app/src/data/curriculum/term3/weeks/week030.ts
+++ b/app/src/data/curriculum/term3/weeks/week030.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "counting": [

--- a/app/src/data/curriculum/term4/weeks/week031.ts
+++ b/app/src/data/curriculum/term4/weeks/week031.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "counting": [

--- a/app/src/data/curriculum/term4/weeks/week032.ts
+++ b/app/src/data/curriculum/term4/weeks/week032.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "addition": [

--- a/app/src/data/curriculum/term4/weeks/week033.ts
+++ b/app/src/data/curriculum/term4/weeks/week033.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "counting": [

--- a/app/src/data/curriculum/term4/weeks/week034.ts
+++ b/app/src/data/curriculum/term4/weeks/week034.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "counting": [

--- a/app/src/data/curriculum/term4/weeks/week035.ts
+++ b/app/src/data/curriculum/term4/weeks/week035.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "counting": [

--- a/app/src/data/curriculum/term4/weeks/week036.ts
+++ b/app/src/data/curriculum/term4/weeks/week036.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "counting": [

--- a/app/src/data/curriculum/term4/weeks/week037.ts
+++ b/app/src/data/curriculum/term4/weeks/week037.ts
@@ -18,70 +18,70 @@ export default {
       "title": "Dalmation",
       "query": "Dalmatian",
       "fact": "A spotted working dog.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "worshond",
       "title": "Worshond",
       "query": "Dachshund",
       "fact": "Also called a sausage dog because of its shape.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "golden-retriever",
       "title": "Golden Retriever",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "windhond",
       "title": "Windhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rifrug",
       "title": "Rifrug",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "ierse-wolfhond",
       "title": "Ierse Wolfhond",
       "query": "Irish Wolfhound",
       "fact": "One of the tallest dog breeds.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "vizsla",
       "title": "Vizsla",
       "query": "Vizsla",
       "fact": "Vizslas are energetic hunting dogs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "skaaphond",
       "title": "Skaaphond",
       "query": "Sheepdog",
       "fact": "Sheepdogs help herd livestock.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "addition": [

--- a/app/src/data/curriculum/term4/weeks/week038.ts
+++ b/app/src/data/curriculum/term4/weeks/week038.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "multiplication": [

--- a/app/src/data/curriculum/term4/weeks/week039.ts
+++ b/app/src/data/curriculum/term4/weeks/week039.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "multiplication": [

--- a/app/src/data/curriculum/term4/weeks/week040.ts
+++ b/app/src/data/curriculum/term4/weeks/week040.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "multiplication": [

--- a/app/src/data/curriculum/term4/weeks/week041.ts
+++ b/app/src/data/curriculum/term4/weeks/week041.ts
@@ -19,70 +19,70 @@ export default {
       "title": "Afgaanse hond",
       "query": "Afghan hound",
       "fact": "This hound has long, silky hair.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "goudkleurige-apporteerhond",
       "title": "Goudkleurige Apporteerhond",
       "query": "Golden Retriever",
       "fact": "This retriever loves to fetch.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dalmatiese-hond",
       "title": "Dalmatiese hond",
       "query": "Dalmatian",
       "fact": "Known for its white coat with black spots.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "dashond",
       "title": "Dashond",
       "query": "Dachshund",
       "fact": "This breed has a long body and short legs.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "franse-dashond",
       "title": "Franse Dashond",
       "query": "Basset Hound",
       "fact": "A playful companion from France.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "jagwindhond",
       "title": "Jagwindhond",
       "query": "greyhound",
       "fact": "This sighthound can run very fast.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bulhond",
       "title": "Bulhond",
       "query": "Bulldog",
       "fact": "Bulldogs have a distinctive wrinkled face.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "engelse-patryshond",
       "title": "Engelse Patryshond",
       "query": "English pointer",
       "fact": "English Pointers excel at bird hunting.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "bloedhond",
       "title": "Bloedhond",
       "query": "Bloodhound",
       "fact": "Bloodhounds have an exceptional sense of smell.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     },
     {
       "id": "rhodesiese-rifrughond",
       "title": "Rhodesiese Rifrughond",
       "query": "Rhodesian Ridgeback",
       "fact": "This dog has a ridge of hair along its back.",
-      "image": "/images/dog.svg"
+      "image": "dog.svg"
     }
   ],
   "multiplication": [

--- a/app/utils/imageMap.ts
+++ b/app/utils/imageMap.ts
@@ -10,5 +10,7 @@ export const imageMap: { [key: string]: any } = {
     'ierse-wolfhond.svg': require('../assets/images/ierse-wolfhond.jpg'),
     'vizsla.svg': require('../assets/images/vizsla.jpg'),
     'skaaphond.svg': require('../assets/images/skaaphond.jpg'),
+    'dog.svg': require('../assets/images/worshond.jpeg'),
+    'placeholder.png': require('../assets/images/worshond.jpeg'),
   };
   


### PR DESCRIPTION
## Summary
- remove `/images/` prefixes from all curriculum week data
- add default image entries to `imageMap`
- document new image key format

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6863adf5806c832e878a82c925034d1e