### PR TITLE
Add Jest test for slide generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ Week content is bundled statically through `app/utils/weekDataMap.ts`. If you
 add or rename week files in `app/src/data/curriculum`, be sure to update the
 imports in `weekDataMap.ts` so the app can load the new data in both web and
 native builds.
+
+## Running Tests
+
+Run the unit test suite with:
+
+```bash
+npm test
+```

--- a/app/utils/__tests__/generateSessionSlides.test.ts
+++ b/app/utils/__tests__/generateSessionSlides.test.ts
@@ -1,0 +1,27 @@
+import { generateSessionSlides } from '../generateSessionSlides';
+import week011 from '../../src/data/curriculum/term2/weeks/week011';
+import { ChildProfile } from '../../src/models/types';
+
+jest.mock('../loadWeekData', () => ({
+  loadWeekData: jest.fn(() => Promise.resolve(week011)),
+}));
+
+jest.mock('../progress', () => ({
+  getTodaySessionCount: jest.fn(() => Promise.resolve(0)),
+}));
+
+describe('generateSessionSlides', () => {
+  const profile: ChildProfile = {
+    id: 'test',
+    name: 'Test',
+    birthday: '2020-01-01',
+    avatar: '😀',
+    createdAt: Date.now(),
+    startDate: '2020-01-01',
+  };
+
+  it('includes at least one math slide for week 11', async () => {
+    const slides = await generateSessionSlides(11, profile);
+    expect(slides.some((s) => s.type === 'math')).toBe(true);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/config-plugins": "~10.0.0",
@@ -49,7 +50,9 @@
     "@tsconfig/react-native": "^3.0.6",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- create a basic Jest setup
- add a unit test for `generateSessionSlides`
- expose `npm test` script
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657b0c875c832e966c3a76af51bd73