### PR TITLE
Add debug logs for last viewed week and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Run the unit test suite with:
 ```bash
 npm test
 ```
+
+## Debugging Progress Storage
+
+The `setLastViewedWeek` and `getLastViewedWeek` helpers now log the profile ID and week
+whenever progress is saved or retrieved. Check the Metro console while running the
+app to verify that week changes are persisted correctly.

--- a/app/utils/__tests__/progress.test.ts
+++ b/app/utils/__tests__/progress.test.ts
@@ -1,0 +1,27 @@
+import { setLastViewedWeek, getLastViewedWeek } from '../progress';
+
+const storage: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn((key: string, value: string) => {
+      storage[key] = value;
+      return Promise.resolve();
+    }),
+    getItem: jest.fn((key: string) => Promise.resolve(storage[key] ?? null)),
+  },
+}));
+
+describe('last viewed week persistence', () => {
+  it('stores and retrieves the last viewed week', async () => {
+    await setLastViewedWeek('p1', 4);
+    const week = await getLastViewedWeek('p1');
+    expect(week).toBe(4);
+  });
+
+  it('defaults to 1 when no value stored', async () => {
+    const week = await getLastViewedWeek('unknown');
+    expect(week).toBe(1);
+  });
+});

--- a/app/utils/progress.ts
+++ b/app/utils/progress.ts
@@ -20,13 +20,16 @@ const pendingKey = (profileId: string) => `pending-${profileId}`;
 const CURRENT_WEEK_KEY = (profileId: string) => `current-week-${profileId}`;
 
 export async function setLastViewedWeek(profileId: string, week: number) {
+  console.log('[progress] setLastViewedWeek', { profileId, week });
   await AsyncStorage.setItem(CURRENT_WEEK_KEY(profileId), String(week));
 }
 
 export async function getLastViewedWeek(profileId: string): Promise<number> {
   const raw = await AsyncStorage.getItem(CURRENT_WEEK_KEY(profileId));
-  const parsed = raw ? parseInt(raw) : null;
-  return parsed && !isNaN(parsed) ? parsed : 1;
+  const parsed = raw ? parseInt(raw, 10) : null;
+  const week = parsed && !isNaN(parsed) ? parsed : 1;
+  console.log('[progress] getLastViewedWeek', { profileId, week });
+  return week;
 }
 
 


### PR DESCRIPTION
## Summary
- add logging to `setLastViewedWeek` and `getLastViewedWeek`
- test persistence of last viewed week
- document new debug logs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657bc7b910832ebd191797ba6534c4